### PR TITLE
63 default config not handled in oarepo vocabularies

### DIFF
--- a/oarepo_vocabularies/authorities/ext.py
+++ b/oarepo_vocabularies/authorities/ext.py
@@ -19,8 +19,15 @@ class OARepoVocabulariesAuthorities(object):
     
     def init_app(self, app):
         """Flask application initialization."""
+        self.init_config(app)
         self.init_resource(app)
         app.extensions["oarepo-vocabularies-authorities"] = self
+        
+    def init_config(self, app):
+        from . import ext_config
+        
+        app.config.setdefault("OAREPO_VOCABULARIES_AUTHORITIES", ext_config.OAREPO_VOCABULARIES_AUTHORITIES)
+        app.config.setdefault("OAREPO_VOCABULARIES_AUTHORITIES_CONFIG", ext_config.OAREPO_VOCABULARIES_AUTHORITIES_CONFIG)
         
     def init_resource(self, app):
         """Initialize resources."""

--- a/oarepo_vocabularies/authorities/ext_config.py
+++ b/oarepo_vocabularies/authorities/ext_config.py
@@ -1,0 +1,7 @@
+from oarepo_vocabularies.authorities.resources import (
+    AuthoritativeVocabulariesResource,
+    AuthoritativeVocabulariesResourceConfig
+)
+
+OAREPO_VOCABULARIES_AUTHORITIES = AuthoritativeVocabulariesResource
+OAREPO_VOCABULARIES_AUTHORITIES_CONFIG = AuthoritativeVocabulariesResourceConfig

--- a/oarepo_vocabularies/config.py
+++ b/oarepo_vocabularies/config.py
@@ -1,9 +1,5 @@
 from invenio_records_resources.services.custom_fields.text import KeywordCF
 
-from oarepo_vocabularies.authorities.resources import (
-    AuthoritativeVocabulariesResource,
-    AuthoritativeVocabulariesResourceConfig
-)
 from oarepo_vocabularies.fixtures import (
     VocabularyReader,
     VocabularyWriter,
@@ -79,6 +75,3 @@ DEFAULT_DATASTREAMS_WRITERS = {"vocabulary": VocabularyWriter}
 
 VOCABULARIES_FACET_CACHE_SIZE = 2048
 VOCABULARIES_FACET_CACHE_TTL = 60 * 24 * 24
-
-OAREPO_VOCABULARIES_AUTHORITIES = AuthoritativeVocabulariesResource
-OAREPO_VOCABULARIES_AUTHORITIES_CONFIG = AuthoritativeVocabulariesResourceConfig

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = oarepo-vocabularies
-version = 2.0.11
+version = 2.0.13
 description = Support for custom fields and hierarchy on Invenio vocabularies
 authors = Mirek Simek <miroslav.simek@cesnet.cz>
 readme = README.md


### PR DESCRIPTION
The main problem is in the nondeterminism of the loading order of configs. Moved it to its own config for the authoritative ext.