### PR TITLE
Support for creating authority vocab items during saving referencing record

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,44 @@ VOCABULARIES_RESOURCE_CONFIG = VocabulariesResourceConfig
 ## Documentation
 
 See [NRP documentation](https://narodni-repozitar.github.io/developer-docs/docs/technology/invenio/nrp-toolchain/plugins/vocabularies) for more details.
+
+## Authorities
+
+It is possible to provide authority sources for vocabularies.
+Configuration:
+
+```python
+VOCABULARY_TYPE_METADATA = {
+    "funding": {    # vocabulary of funding
+        "name": {
+            "en": "Funding"
+        },
+        "authority": FundingService
+    }
+}
+```
+
+where:
+
+```python
+from oarepo_vocabularies.authorities import AuthorityService
+
+class FundingService(AuthorityService):
+    def search(self, query=None, page=1, size=10):
+        # performs an API and returns a listing 
+        # of serialized vocabulary items, for example:
+        return {
+            'hits': {
+                'total': 2,
+                'hits': [
+                    {"id": "03zsq2967", "title": {"en": "Funding 1"}},
+                    {"id": "a4gfhtt56", "title": {"en": "Funding 2"}}
+                ]
+            },
+            # optional pagination links here
+        }
+    def get(self, item_id):
+        # performs lookup by id and returns vocabulary metadata
+        # in this example:
+        return next(x for x in self.search()['hits']['hits'] if x['id'] == item_id)
+```

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ where:
 from oarepo_vocabularies.authorities import AuthorityService
 
 class FundingService(AuthorityService):
-    def search(self, query=None, page=1, size=10):
+    def search(self, query=None, page=1, size=10, **kwargs):
         # performs an API and returns a listing 
         # of serialized vocabulary items, for example:
         return {
@@ -56,8 +56,9 @@ class FundingService(AuthorityService):
             },
             # optional pagination links here
         }
-    def get(self, item_id):
+    def get(self, item_id, *, uow, value, **kwargs):
         # performs lookup by id and returns vocabulary metadata
+        
         # in this example:
         return next(x for x in self.search()['hits']['hits'] if x['id'] == item_id)
 ```

--- a/oarepo_vocabularies/authorities/__init__.py
+++ b/oarepo_vocabularies/authorities/__init__.py
@@ -1,0 +1,3 @@
+from .service import AuthorityService
+
+__all__ = ("AuthorityService",)

--- a/oarepo_vocabularies/authorities/components.py
+++ b/oarepo_vocabularies/authorities/components.py
@@ -1,0 +1,97 @@
+import inspect
+
+from invenio_records_resources.services.records.components import ServiceComponent
+
+from oarepo_runtime.relations.errors import (
+    MultipleInvalidRelationErrors,
+    InvalidRelationError,
+)
+from oarepo_runtime.relations.mapping import RelationsMapping
+from oarepo_vocabularies.authorities.proxies import authorities
+from invenio_vocabularies.records.systemfields import VocabularyPIDFieldContext
+
+from oarepo_vocabularies.authorities.service import AuthorityService
+from invenio_vocabularies.proxies import current_service as vocabulary_service
+from invenio_access.permissions import system_identity
+from invenio_db import db
+
+
+class AuthorityComponent(ServiceComponent):
+    def create(self, identity, data=None, record=None, errors=None, **kwargs):
+        self.lookup_and_store_authority_records(record)
+
+    def update(self, identity, data=None, record=None, **kwargs):
+        self.lookup_and_store_authority_records(record)
+
+    def lookup_and_store_authority_records(self, record):
+        # get the relations system field
+        relations_fields = inspect.getmembers(
+            record, lambda x: isinstance(x, RelationsMapping)
+        )
+
+        for relations_field_name, relations in relations_fields:
+            # iterate all vocabularies there, check that the item exists
+            for fld_name in relations:
+                fld = getattr(relations, fld_name)
+                try:
+                    pid_context = fld.field.pid_field
+                except:
+                    continue
+                if not isinstance(pid_context, VocabularyPIDFieldContext):
+                    continue
+                try:
+                    fld.validate(raise_first_exception=False)
+                except MultipleInvalidRelationErrors as e:
+                    # check if there is an authority service
+                    vocabulary_type = pid_context._type_id
+                    authority_service = authorities.get_authority_api(vocabulary_type)
+
+                    if not authority_service:
+                        raise
+
+                    # if so, for each record store the authority record
+                    for err in e.errors:
+                        self.resolve_and_store_authority_record(
+                            fld,
+                            result=err[0],
+                            error=err[1],
+                            authority_service=authority_service,
+                            vocabulary_type=vocabulary_type,
+                        )
+
+                    # and run again validate to populate this record with de-referenced value
+                    fld.validate()
+
+    def resolve_and_store_authority_record(
+        self,
+        fld,
+        *,
+        result,
+        error,
+        authority_service: AuthorityService,
+        vocabulary_type,
+    ):
+        value = result.value or {}
+        if "id" not in value:
+            raise InvalidRelationError(
+                f"'id' not found in relation value {value}",
+                related_id=None,
+                location=result.path,
+            )
+        item_id = value["id"]
+        try:
+            fetched_item = authority_service.get(item_id)
+        except Exception as e:
+            raise InvalidRelationError(
+                f"External authority failed: {e}",
+                related_id=item_id,
+                location=result.path,
+            ) from e
+
+        with db.session.begin_nested():
+            rec = vocabulary_service.create(
+                system_identity, {**fetched_item, "type": vocabulary_type}, uow=self.uow
+            )
+            # possible optimization - put the created vocab item to the cache on fld.cache
+            # in the form: ('<pid-type>', '<id>'): {created record}
+            # so that it is not fetched again from the database

--- a/oarepo_vocabularies/authorities/ext.py
+++ b/oarepo_vocabularies/authorities/ext.py
@@ -9,24 +9,20 @@ class OARepoVocabulariesAuthorities(object):
     def __init__(self, app=None):
         """Extension initialization."""
         self.resource = None
+        self.app = app
         if app:
             self.init_app(app)
 
     @lru_cache(maxsize=None)
-    def auth_getter(self, app, vocabulary_type: str):
-        vocabularies_metadata = app.config["INVENIO_VOCABULARY_TYPE_METADATA"]
-        authority_section = vocabularies_metadata[vocabulary_type].get(
-            "authority", None
-        )
-
-        return (
-            authority_section.get(obj_or_import_string("getter"), None)
-            if authority_section
-            else None
-        )
+    def get_authority_api(self, vocabulary_type: str):
+        vocabularies_metadata = self.app.config["INVENIO_VOCABULARY_TYPE_METADATA"]
+        authority = vocabularies_metadata[vocabulary_type].get("authority", None)
+        if authority:
+            return obj_or_import_string(authority)()
 
     def init_app(self, app):
         """Flask application initialization."""
+        self.app = app
         self.init_config(app)
         self.init_resource(app)
         app.extensions["oarepo-vocabularies-authorities"] = self

--- a/oarepo_vocabularies/authorities/proxies.py
+++ b/oarepo_vocabularies/authorities/proxies.py
@@ -2,11 +2,6 @@ from flask import current_app
 from werkzeug.local import LocalProxy
 
 
-def _ext_proxy(attr):
-    return LocalProxy(
-        lambda: getattr(current_app.extensions["oarepo-vocabularies-authorities"], attr)
+authorities = LocalProxy(
+        lambda: current_app.extensions["oarepo-vocabularies-authorities"]
     )
-
-
-current_vocabularies_authorities = _ext_proxy("auth_getter")
-"""Proxy to the instantiated vocabulary authorities."""

--- a/oarepo_vocabularies/authorities/proxies.py
+++ b/oarepo_vocabularies/authorities/proxies.py
@@ -1,7 +1,6 @@
 from flask import current_app
 from werkzeug.local import LocalProxy
 
-
 authorities = LocalProxy(
-        lambda: current_app.extensions["oarepo-vocabularies-authorities"]
-    )
+    lambda: current_app.extensions["oarepo-vocabularies-authorities"]
+)

--- a/oarepo_vocabularies/authorities/resources/resource.py
+++ b/oarepo_vocabularies/authorities/resources/resource.py
@@ -6,7 +6,6 @@ from invenio_records_resources.resources.records.resource import (
     request_view_args,
 )
 from invenio_vocabularies.records.models import VocabularyType
-from sqlalchemy.orm import aliased
 
 from oarepo_vocabularies.authorities.proxies import authorities
 from oarepo_vocabularies.authorities.service import AuthorityService

--- a/oarepo_vocabularies/authorities/resources/resource.py
+++ b/oarepo_vocabularies/authorities/resources/resource.py
@@ -54,5 +54,4 @@ class AuthoritativeVocabulariesResource(Resource):
             auth_id = item["id"]
             item.setdefault("props", {})["external"] = auth_id not in query_results
 
-        result = results
-        return result, 200
+        return results, 200

--- a/oarepo_vocabularies/authorities/resources/resource.py
+++ b/oarepo_vocabularies/authorities/resources/resource.py
@@ -5,9 +5,11 @@ from invenio_records_resources.resources.records.resource import (
     request_search_args,
     request_view_args,
 )
+from invenio_vocabularies.records.models import VocabularyType
 from sqlalchemy.orm import aliased
 
-from oarepo_vocabularies.authorities.proxies import current_vocabularies_authorities
+from oarepo_vocabularies.authorities.proxies import authorities
+from oarepo_vocabularies.authorities.service import AuthorityService
 
 
 class AuthoritativeVocabulariesResource(Resource):
@@ -23,51 +25,34 @@ class AuthoritativeVocabulariesResource(Resource):
     @request_view_args
     @response_handler()
     def list(self):
-        auth_getter = current_vocabularies_authorities(
+        authority_service: AuthorityService = authorities.get_authority_api(
             resource_requestctx.view_args["type"]
         )
-        if not auth_getter:
+        vocabulary_type = VocabularyType.query.filter_by(
+            id=resource_requestctx.view_args["type"]
+        ).one()
+        if not authority_service:
             return "No authority getter.", 404
 
         # Get hits from authority.
         params = resource_requestctx.args
         q, page, size = params["q"], params["page"], params["size"]
-        results = auth_getter(q, page, size)
+        results = authority_service.search(query=q, page=page, size=size)
 
         # Mark external, resolve uuid.
-        authoritative_ids = [item["props"]["authoritative_id"] for item in results]
+        ids = [item["id"] for item in results["hits"]["hits"]]
 
-        authvc = db.session.query(
-            PersistentIdentifier.pid_value, PersistentIdentifier.object_uuid
-        ).filter(
+        internal_query = db.session.query(PersistentIdentifier.pid_value).filter(
             db.and_(
-                PersistentIdentifier.pid_type == "authvc",
-                PersistentIdentifier.pid_value.in_(authoritative_ids),
+                PersistentIdentifier.pid_type == vocabulary_type.pid_type,
+                PersistentIdentifier.pid_value.in_(ids),
             )
         )
+        query_results = {row.pid_value for row in internal_query}
 
-        PersistentIdentifierAlias = aliased(PersistentIdentifier)
-        query = authvc.join(
-            PersistentIdentifierAlias,
-            PersistentIdentifier.object_uuid == PersistentIdentifierAlias.object_uuid,
-        )
+        for item in results["hits"]["hits"]:
+            auth_id = item["id"]
+            item.setdefault("props", {})["external"] = auth_id not in query_results
 
-        query_results = query.all()
-        query_results = {row.pid_value: row.object_uuid for row in query_results}
-
-        authority_results = []
-        for item in results:
-            auth_id = item["props"]["authoritative_id"]
-
-            if auth_id not in query_results:
-                item["props"]["external"] = True
-                authority_results.append(item)
-                continue
-
-            uuid = query_results[auth_id]
-            item["props"]["external"] = uuid is None
-            item["props"]["uuid"] = uuid
-            authority_results.append(item)
-
-        result = {"hits": {"hits": authority_results}}
+        result = results
         return result, 200

--- a/oarepo_vocabularies/authorities/service.py
+++ b/oarepo_vocabularies/authorities/service.py
@@ -3,7 +3,7 @@ import abc
 
 class AuthorityService(abc.ABC):
     @abc.abstractmethod
-    def search(self, *, query=None, page=1, size=10):
+    def search(self, *, query=None, page=1, size=10, **kwargs):
         """
         Search the external authority service by the given text query and return
         page & size with the data. The returned structure must be the same as Invenio
@@ -26,7 +26,7 @@ class AuthorityService(abc.ABC):
         """
 
     @abc.abstractmethod
-    def get(self, item_id):
+    def get(self, item_id, **kwargs):
         """
         Gets vocabulary item by id. Returns the item as JSON or KeyError if the item could not be found.
         """

--- a/oarepo_vocabularies/authorities/service.py
+++ b/oarepo_vocabularies/authorities/service.py
@@ -1,0 +1,32 @@
+import abc
+
+
+class AuthorityService(abc.ABC):
+    @abc.abstractmethod
+    def search(self, *, query=None, page=1, size=10):
+        """
+        Search the external authority service by the given text query and return
+        page & size with the data. The returned structure must be the same as Invenio
+        vocabulary listing, that is:
+        ```
+        {
+            'hits': {
+                'total': <number of results>,
+                'hits': [
+                    {'id': 1, title: {'en': ...}, ...},
+                    {'id': 1, title: {'en': ...}, ...},
+                ]
+            },
+            'links': {
+                'self': ...,
+                'next': ...
+            }
+        }
+        ```
+        """
+
+    @abc.abstractmethod
+    def get(self, item_id):
+        """
+        Gets vocabulary item by id. Returns the item as JSON or KeyError if the item could not be found.
+        """

--- a/oarepo_vocabularies/authorities/service.py
+++ b/oarepo_vocabularies/authorities/service.py
@@ -26,7 +26,10 @@ class AuthorityService(abc.ABC):
         """
 
     @abc.abstractmethod
-    def get(self, item_id, **kwargs):
+    def get(self, item_id, *, uow, value, **kwargs):
         """
         Gets vocabulary item by id. Returns the item as JSON or KeyError if the item could not be found.
+        @param item_id  value['id']
+        @param uow      actual unit of work (if you need to create something inside the db, do it inside this uow)
+        @param value    the value passed from the client
         """

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = oarepo-vocabularies
-version = 2.0.32
+version = 2.0.33
 description = Support for custom fields and hierarchy on Invenio vocabularies
 authors = Mirek Simek <miroslav.simek@cesnet.cz>
 readme = README.md

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,7 +54,6 @@ from invenio_accounts.proxies import current_datastore
 from invenio_accounts.testutils import login_user_via_session
 from invenio_app.factory import create_app as _create_app
 from invenio_cache import current_cache
-from invenio_pidstore.models import PersistentIdentifier
 from invenio_vocabularies.records.api import Vocabulary
 from invenio_vocabularies.records.models import VocabularyType
 
@@ -408,7 +407,7 @@ def authority_rec(db, identity, authority_type, service, vocab_cf):
 
 
 class AuthService(AuthorityService):
-    def search(self, query=None, page=1, size=10):
+    def search(self, query=None, page=1, size=10, **kwargs):
         return {
             "hits": {
                 "total": 2,
@@ -429,7 +428,7 @@ class AuthService(AuthorityService):
             }
         }
 
-    def get(self, item_id):
+    def get(self, item_id, **kwargs):
         return next(x for x in self.search()["hits"]["hits"] if x["id"] == item_id)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,7 @@ import shutil
 import sys
 from pathlib import Path
 
+from oarepo_vocabularies.authorities.service import AuthorityService
 from oarepo_vocabularies.ui.resources.components import (
     DepositVocabularyOptionsComponent,
 )
@@ -151,6 +152,10 @@ def app_config(app_config):
                 "en": "lincenses vocabulary type.",
             },
         },
+        "authority": {
+            "name": {"en": "authority"},
+            "authority": AuthService,
+        },
     }
 
     app_config["APP_THEME"] = ["semantic-ui"]
@@ -195,6 +200,14 @@ def service(app):
 def lang_type(db):
     """Get a language vocabulary type."""
     v = VocabularyType.create(id="languages", pid_type="lng")
+    db.session.commit()
+    return v
+
+
+@pytest.fixture()
+def authority_type(db):
+    """Get a language vocabulary type."""
+    v = VocabularyType.create(id="authority", pid_type="v-auth")
     db.session.commit()
     return v
 
@@ -381,57 +394,43 @@ def empty_licences(db):
 
 
 @pytest.fixture()
-def affiliations_pids(db):
-    def _upload(uuid):
-        # One of the samples already exists and the other one is a completely new one.
-        invenio_pid = PersistentIdentifier.create(
-            pid_type="id",
-            pid_value="invenioid1",
-            object_type="object",
-            object_uuid=uuid,
-        )
-
-        authvc_pid = PersistentIdentifier.create(
-            pid_type="authvc",
-            pid_value="authid1",
-            object_type="object",
-            object_uuid=uuid,
-        )
-
-        db.session.add(invenio_pid)
-        db.session.add(authvc_pid)
-        db.session.commit()
-
-    return _upload
-
-
-@pytest.fixture()
-def mock_auth_getter_affilliations(mocker):
-    """
-    ROR-like samples.
-    """
-    mock = mocker.patch(
-        "oarepo_vocabularies.authorities.ext.OARepoVocabulariesAuthorities.auth_getter"
+def authority_rec(db, identity, authority_type, service, vocab_cf):
+    return service.create(
+        identity=identity,
+        data={
+            "id": "020bcb226",
+            "title": {
+                "en": "Oakton Community College",
+            },
+            "type": authority_type.id,
+        },
     )
 
-    mock.return_value = lambda q, page, size: [
-        {
-            "id": "https://ror.org/03zsq2967",
-            "props": {
-                "authoritative_id": "authid1",
-                "name": "Association of Asian Pacific Community Health Organizations",
-            },
-        },
-        {
-            "id": "https://ror.org/020bcb226",
-            "props": {
-                "authoritative_id": "authid2",
-                "name": "Oakton Community College",
-            },
-        },
-    ]
 
-    yield mock
+class AuthService(AuthorityService):
+    def search(self, query=None, page=1, size=10):
+        return {
+            "hits": {
+                "total": 2,
+                "hits": [
+                    {
+                        "id": "03zsq2967",
+                        "title": {
+                            "en": "Association of Asian Pacific Community Health Organizations",
+                        },
+                    },
+                    {
+                        "id": "020bcb226",
+                        "title": {
+                            "en": "Oakton Community College",
+                        },
+                    },
+                ],
+            }
+        }
+
+    def get(self, item_id):
+        return next(x for x in self.search()["hits"]["hits"] if x["id"] == item_id)
 
 
 @pytest.fixture()
@@ -457,3 +456,13 @@ def vocabularies_ui_resource_config(app):
 @pytest.fixture
 def vocabularies_ui_resource(app, vocabularies_ui_resource_config):
     return InvenioVocabulariesUIResource(vocabularies_ui_resource_config)
+
+
+@pytest.fixture(scope="module")
+def simple_record_service(app):
+    from .simple_model import ModelService, ModelServiceConfig
+
+    service = ModelService(ModelServiceConfig())
+    sregistry = app.extensions["invenio-records-resources"].registry
+    sregistry.register(service, service_id="simple_model")
+    return service

--- a/tests/simple_model.py
+++ b/tests/simple_model.py
@@ -1,0 +1,114 @@
+import marshmallow as ma
+from flask_resources import BaseListSchema, MarshmallowSerializer
+from flask_resources.serializers import JSONSerializer
+from invenio_pidstore.providers.recordid_v2 import RecordIdProviderV2
+from invenio_records.models import RecordMetadata
+from invenio_records_permissions import RecordPermissionPolicy
+from invenio_records_permissions.generators import AnyUser, SystemProcess
+from invenio_records_resources.records.api import Record
+from invenio_records_resources.records.systemfields import IndexField, PIDField
+from invenio_records_resources.records.systemfields.pid import PIDFieldContext
+from invenio_records_resources.services import (
+    RecordLink,
+    RecordService,
+    RecordServiceConfig,
+)
+from invenio_records_resources.services.records.components import DataComponent
+from invenio_vocabularies.records.api import Vocabulary
+
+from oarepo_ui.resources import (
+    BabelComponent,
+    RecordsUIResource,
+    RecordsUIResourceConfig,
+)
+from oarepo_ui.resources.components import PermissionsComponent
+
+from oarepo_runtime.relations import RelationsField, PIDRelation
+from oarepo_vocabularies.authorities.components import AuthorityComponent
+
+
+class ModelRecordIdProvider(RecordIdProviderV2):
+    pid_type = "rec"
+
+
+class ModelRecord(Record):
+    index = IndexField("test_record")
+    model_cls = RecordMetadata
+    pid = PIDField(
+        provider=ModelRecordIdProvider, context_cls=PIDFieldContext, create=True
+    )
+    relations = RelationsField(
+        authority=PIDRelation(
+            "authority",
+            keys=["id", "title"],
+            pid_field=Vocabulary.pid.with_type_ctx("authority"),
+        )
+    )
+
+
+class ModelPermissionPolicy(RecordPermissionPolicy):
+    can_create = [AnyUser(), SystemProcess()]
+    can_search = [AnyUser(), SystemProcess()]
+    can_read = [AnyUser(), SystemProcess()]
+
+
+class ModelSchema(ma.Schema):
+    title = ma.fields.String()
+    authority = ma.fields.Raw()  # just a simulation ...
+
+    class Meta:
+        unknown = ma.INCLUDE
+
+
+class ModelServiceConfig(RecordServiceConfig):
+    record_cls = ModelRecord
+    permission_policy_cls = ModelPermissionPolicy
+    schema = ModelSchema
+    components = [DataComponent, AuthorityComponent]
+
+    url_prefix = "/simple-model"
+
+    @property
+    def links_item(self):
+        return {
+            "self": RecordLink("{+api}%s/{id}" % self.url_prefix),
+            "ui": RecordLink("{+ui}%s/{id}" % self.url_prefix),
+        }
+
+
+class ModelService(RecordService):
+    pass
+
+
+class ModelUISerializer(MarshmallowSerializer):
+    """UI JSON serializer."""
+
+    def __init__(self):
+        """Initialise Serializer."""
+        super().__init__(
+            format_serializer_cls=JSONSerializer,
+            object_schema_cls=ModelSchema,
+            list_schema_cls=BaseListSchema,
+            schema_context={"object_key": "ui"},
+        )
+
+
+class ModelUIResourceConfig(RecordsUIResourceConfig):
+    api_service = "simple_model"  # must be something included in oarepo, as oarepo is used in tests
+
+    blueprint_name = "simple_model"
+    url_prefix = "/simple-model"
+    ui_serializer_class = ModelUISerializer
+    templates = {
+        **RecordsUIResourceConfig.templates,
+        "detail": {"layout": "TestDetail.jinja", "blocks": {}},
+        "search": {
+            "layout": "test_detail.html",
+        },
+    }
+
+    components = [BabelComponent, PermissionsComponent]
+
+
+class ModelUIResource(RecordsUIResource):
+    pass

--- a/tests/simple_model.py
+++ b/tests/simple_model.py
@@ -15,7 +15,7 @@ from invenio_records_resources.services import (
 )
 from invenio_records_resources.services.records.components import DataComponent
 from invenio_vocabularies.records.api import Vocabulary
-
+from oarepo_runtime.relations import PIDRelation, RelationsField
 from oarepo_ui.resources import (
     BabelComponent,
     RecordsUIResource,
@@ -23,7 +23,6 @@ from oarepo_ui.resources import (
 )
 from oarepo_ui.resources.components import PermissionsComponent
 
-from oarepo_runtime.relations import RelationsField, PIDRelation
 from oarepo_vocabularies.authorities.components import AuthorityComponent
 
 

--- a/tests/test_authorities.py
+++ b/tests/test_authorities.py
@@ -1,22 +1,38 @@
-def test_authority_resource(
-    client, affiliations_pids, mock_auth_getter_affilliations, search_clear
-):
+from oarepo_vocabularies.records.api import Vocabulary
+from invenio_vocabularies.proxies import current_service as vocabulary_service
+
+
+def test_authority_resource(client, authority_rec, authority_type, search_clear):
     # Arrange.
-    internal_uuid = "{12345678-1234-5678-1234-567812345678}"
-    affiliations_pids(internal_uuid)
 
     # Act.
     params = "q=affiliation&page=1&size=2"
-    resp = client.get(f"/api/vocabularies/affiliations/authoritative?{params}").json
+    resp = client.get(f"/api/vocabularies/authority/authoritative?{params}").json
 
     # Assert.
     results = resp["hits"]["hits"]
-    mock_auth_getter_affilliations.assert_called_once()
 
     external_result = [res for res in results if res["props"]["external"]]
     assert len(external_result) == 1
-    assert not hasattr(external_result[0]["props"], "uuid")
+    assert external_result[0]["id"] == "03zsq2967"
 
     internal_result = [res for res in results if not res["props"]["external"]]
     assert len(internal_result) == 1
-    assert internal_result[0]["props"]["uuid"] == internal_uuid[1:-1]
+    assert internal_result[0]["id"] == "020bcb226"
+
+
+def test_submit_record_fetch_authority(
+    search_clear, identity, authority_type, simple_record_service, vocab_cf
+):
+    response = simple_record_service.create(
+        identity, {"title": "a", "authority": {"id": "03zsq2967"}}
+    )
+    assert response.data["authority"]["id"] == "03zsq2967"
+    assert response.data["authority"]["title"] == {
+        "en": "Association of Asian Pacific Community Health Organizations"
+    }
+    # check that the vocabulary item has been created
+    Vocabulary.index.refresh()
+    assert vocabulary_service.read(identity, ("authority", "03zsq2967")).data[
+        "title"
+    ] == {"en": "Association of Asian Pacific Community Health Organizations"}

--- a/tests/test_authorities.py
+++ b/tests/test_authorities.py
@@ -1,5 +1,6 @@
-from oarepo_vocabularies.records.api import Vocabulary
 from invenio_vocabularies.proxies import current_service as vocabulary_service
+
+from oarepo_vocabularies.records.api import Vocabulary
 
 
 def test_authority_resource(client, authority_rec, authority_type, search_clear):


### PR DESCRIPTION
Added support for on-the-fly creation of authority vocabulary items when referencing record is saved.
It resolves references and when local vocabulary item is not found, a get on authority service is called,
retrieved record stored to the local vocabulary and used inside the record.