### PR TITLE
added breadcrumb to detail page of hierarchical vocabs

### DIFF
--- a/oarepo_vocabularies/ui/templates/semantic-ui/oarepo_vocabularies_ui/VocabulariesBreadcrumb.jinja
+++ b/oarepo_vocabularies/ui/templates/semantic-ui/oarepo_vocabularies_ui/VocabulariesBreadcrumb.jinja
@@ -1,0 +1,25 @@
+{#def metadata, extra_context #}
+
+
+{% set breadcrumbData = {
+    "hierarchical": extra_context.vocabularyProps.hierarchical,
+    "ancestorsOrSelf": metadata.hierarchy.ancestors_or_self|reverse|list,
+    "titles": metadata.hierarchy.title|reverse|list,
+    "vocabularyType": metadata.type,
+} %}
+
+
+{% if breadcrumbData.hierarchical and breadcrumbData.ancestorsOrSelf|length>1 %}
+<div class="ui breadcrumb">
+    {% for index in range(0, breadcrumbData.ancestorsOrSelf|length) %}
+        {% set ancestor = breadcrumbData.ancestorsOrSelf[index] %}
+        {% set title = breadcrumbData.titles[index] %}
+        {% if loop.last %}
+            <div class="active section">{{ title }}</div>
+        {% else %}
+            <a class="section" href="/vocabularies/{{ breadcrumbData.vocabularyType }}/{{ ancestor }}">{{ title }}</a>
+            <div class="divider"> / </div>
+        {% endif %}
+    {% endfor %}
+</div>
+{% endif %}

--- a/oarepo_vocabularies/ui/templates/semantic-ui/oarepo_vocabularies_ui/VocabulariesDetail.jinja
+++ b/oarepo_vocabularies/ui/templates/semantic-ui/oarepo_vocabularies_ui/VocabulariesDetail.jinja
@@ -9,21 +9,17 @@
 
 {% block record_main_content %}
 <oarepo_vocabularies_ui.VocabulariesMain metadata={metadata} ui={ui} url_prefix={url_prefix} record={record} extra_context={extra_context} d={d}></oarepo_vocabularies_ui.VocabulariesMain>
+{% block vocabulary_descendants %}
+{% set search_app_config = extra_context["search_app_config"] %}
+  {%- include "oarepo_vocabularies_ui/descendants.html" -%}
+{% endblock vocabulary_descendants %}
 {% endblock record_main_content %}
 
 {% block record_sidebar %}
 <oarepo_vocabularies_ui.VocabulariesSidebar metadata={metadata} ui={ui} url_prefix={url_prefix} record={record} extra_context={extra_context}></oarepo_vocabularies_ui.VocabulariesSidebar>
 {% endblock record_sidebar %}
 
-{% block page_body %}
-  {{ super() }}
-  <div class="ui center aligned container rel-mb-2">
-    {% block vocabulary_descendants %}
-      {% set search_app_config = extra_context["search_app_config"] %}
-        {%- include "oarepo_vocabularies_ui/descendants.html" -%}
-    {% endblock vocabulary_descendants %}
-  </div>
-{% endblock page_body %}
+
 
 {%- block javascript %}
 {{super()}}

--- a/oarepo_vocabularies/ui/templates/semantic-ui/oarepo_vocabularies_ui/VocabulariesMain.jinja
+++ b/oarepo_vocabularies/ui/templates/semantic-ui/oarepo_vocabularies_ui/VocabulariesMain.jinja
@@ -1,6 +1,7 @@
-{#def metadata, ui, record, d #}
+{#def metadata, ui, record, d, extra_context #}
 
 <div class="vocabularies-main">
+  <VocabulariesBreadcrumb extra_context={extra_context} metadata={metadata} />
   <div class="flex align-items-center rel-mt-1">
     {% if record.icon %}
       <img class="ui image rel-mr-1" src={{record.icon}}>

--- a/oarepo_vocabularies/ui/theme/assets/semantic-ui/js/oarepo_vocabularies_ui/detail/DetailSearchApp.jsx
+++ b/oarepo_vocabularies/ui/theme/assets/semantic-ui/js/oarepo_vocabularies_ui/detail/DetailSearchApp.jsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from "react";
 import PropTypes from "prop-types";
 import { OverridableContext } from "react-overridable";
-import { Container, Grid, Label } from "semantic-ui-react";
+import { Container, Grid, Header } from "semantic-ui-react";
 import {
   EmptyResults,
   Error,
@@ -19,9 +19,9 @@ const OnResults = withState(Results);
 
 const CountElement = ({ totalResults }) => {
   return (
-    <Label size="large">
+    <Header as="h3">
       {i18next.t("totalDescendants", { count: totalResults })}
-    </Label>
+    </Header>
   );
 };
 

--- a/oarepo_vocabularies/ui/theme/assets/semantic-ui/js/oarepo_vocabularies_ui/detail/Results.jsx
+++ b/oarepo_vocabularies/ui/theme/assets/semantic-ui/js/oarepo_vocabularies_ui/detail/Results.jsx
@@ -32,6 +32,7 @@ export const Results = ({ resultsPerPageValues, currentResultsState }) => {
             textAlign="center"
           >
             <Pagination
+              showWhenOnlyOnePage={false}
               options={{
                 size: "mini",
                 showFirst: false,
@@ -41,6 +42,7 @@ export const Results = ({ resultsPerPageValues, currentResultsState }) => {
           </Grid.Column>
           <Grid.Column className="mobile only" width={16} textAlign="center">
             <Pagination
+              showWhenOnlyOnePage={false}
               options={{
                 boundaryRangeCount: 0,
                 showFirst: false,
@@ -54,6 +56,7 @@ export const Results = ({ resultsPerPageValues, currentResultsState }) => {
             width={4}
           >
             <ResultsPerPage
+              showWhenOnlyOnePage={false}
               values={resultsPerPageValues}
               label={resultsPerPageLabel}
             />
@@ -64,6 +67,7 @@ export const Results = ({ resultsPerPageValues, currentResultsState }) => {
             width={16}
           >
             <ResultsPerPage
+              showWhenOnlyOnePage={false}
               values={resultsPerPageValues}
               label={resultsPerPageLabel}
             />


### PR DESCRIPTION
Added breadcrumbs to detail page for hierarchical vocabularies and also moved search app to be part of main section (in order to not have a big gap between item metadata and descendants search app in case where record has very few metadata, which is almost always. 