### PR TITLE
feat(remote): hotfix add new form until full custom fields support

### DIFF
--- a/oarepo_vocabularies/ui/theme/assets/semantic-ui/js/oarepo_vocabularies_ui/form/components/VocabularyRemoteSelectField/VocabularyRemoteSelectModal.jsx
+++ b/oarepo_vocabularies/ui/theme/assets/semantic-ui/js/oarepo_vocabularies_ui/form/components/VocabularyRemoteSelectField/VocabularyRemoteSelectModal.jsx
@@ -27,7 +27,8 @@ export const VocabularyRemoteSelectModal = ({
   const inAddMode = action === ModalActions.ADD;
 
   const addNew = React.useCallback(() => {
-    setAction(ModalActions.ADD);
+    window.open(`/vocabularies/${vocabulary}/_new`, '_blank').focus()
+    // setAction(ModalActions.ADD);
   });
 
   const backToSearch = React.useCallback(() => {
@@ -89,13 +90,14 @@ export const VocabularyRemoteSelectModal = ({
             }
           />
         )}
-        {inAddMode && (
-          <VocabularyAddItemForm
-            overriddenComponents={overriddenComponents}
-            backToSearch={backToSearch}
-            onSubmit={handleNewItem}
-          />
-        )}
+        {/* TODO: implement this with full custom fields support. */}
+        {/*{inAddMode && (*/}
+        {/*  <VocabularyAddItemForm*/}
+        {/*    overriddenComponents={overriddenComponents}*/}
+        {/*    backToSearch={backToSearch}*/}
+        {/*    onSubmit={handleNewItem}*/}
+        {/*  />*/}
+        {/*)}*/}
       </>
     </Modal>
   );

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = oarepo-vocabularies
-version = 2.1.0
+version = 2.1.1
 description = Support for custom fields and hierarchy on Invenio vocabularies
 authors = Mirek Simek <miroslav.simek@cesnet.cz>
 readme = README.md


### PR DESCRIPTION
There's missing API support regarding `formConfig`  (custom fields config) for vocabularies, this PR
temporarliy rewires add new button to open vocabulary item creation form page on a new tab