### PR TITLE
fix: Broken form_config API usage

### DIFF
--- a/oarepo_vocabularies/ui/resources/config.py
+++ b/oarepo_vocabularies/ui/resources/config.py
@@ -84,9 +84,9 @@ class InvenioVocabulariesUIResourceConfig(RecordsUIResourceConfig):
             vocabulary_type, {}
         )
 
-    def _get_custom_fields_ui_config(self, key, resource_requestctx=None, **kwargs):
+    def _get_custom_fields_ui_config(self, key, view_args=None, **kwargs):
         if key == "OAREPO_VOCABULARIES_HIERARCHY_CF":
             return []
         return current_app.config.get("VOCABULARIES_CF_UI", {}).get(
-            resource_requestctx.view_args["vocabulary_type"], []
+            view_args["vocabulary_type"], []
         )

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = oarepo-vocabularies
-version = 2.1.1
+version = 2.1.2
 description = Support for custom fields and hierarchy on Invenio vocabularies
 authors = Mirek Simek <miroslav.simek@cesnet.cz>
 readme = README.md


### PR DESCRIPTION
* The form_config API has been changed in oarepo-ui to not be dependent on resource_requestctx, thus breaking the vocabularies form config

* this commit switches to the new API