### PR TITLE
fixed up props fields

### DIFF
--- a/oarepo_vocabularies/ui/theme/assets/semantic-ui/js/oarepo_vocabularies_ui/form/components/PropFieldsComponent/PropFieldsComponent.jsx
+++ b/oarepo_vocabularies/ui/theme/assets/semantic-ui/js/oarepo_vocabularies_ui/form/components/PropFieldsComponent/PropFieldsComponent.jsx
@@ -1,12 +1,10 @@
 import React from "react";
 import { Popup, Icon } from "semantic-ui-react";
-import { i18next } from "@translations/oarepo_vocabularies_ui/i18next";
 import PropTypes from "prop-types";
 import { TextField, FieldLabel } from "react-invenio-forms";
 
 export const PropFieldsComponent = ({ vocabularyProps }) => {
   const { props } = vocabularyProps;
-
   return (
     <React.Fragment>
       {Object.entries(props).map(([propField, propConfig]) => (
@@ -21,7 +19,7 @@ export const PropFieldsComponent = ({ vocabularyProps }) => {
                 icon="pencil"
                 label={
                   <React.Fragment>
-                    {i18next.t(propField)}{" "}
+                    {propConfig?.label || propField}{" "}
                     <Popup
                       content={propConfig.description}
                       trigger={<Icon name="question circle" color="blue" />}
@@ -33,7 +31,7 @@ export const PropFieldsComponent = ({ vocabularyProps }) => {
               <FieldLabel
                 htmlFor={propField}
                 icon="pencil"
-                label={i18next.t(propField)}
+                label={propConfig?.label || propField}
               />
             )
           }

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = oarepo-vocabularies
-version = 2.1.23
+version = 2.1.24
 description = Support for custom fields and hierarchy on Invenio vocabularies
 authors = Mirek Simek <miroslav.simek@cesnet.cz>
 readme = README.md


### PR DESCRIPTION
This PR only fixes a minor issue we had with inputs for fields that fall into "props" of a vocabulary item (because it was not using the label for input label, but actual field path). Also here https://github.com/Narodni-repozitar/nr-docs/pull/287 fixed using incorrect props for resource-types vocabulary