### PR TITLE
fixed remote vocabulary select

### DIFF
--- a/oarepo_vocabularies/ui/theme/assets/semantic-ui/js/oarepo_vocabularies_ui/form/components/VocabularySelectField/VocabularySelectField.jsx
+++ b/oarepo_vocabularies/ui/theme/assets/semantic-ui/js/oarepo_vocabularies_ui/form/components/VocabularySelectField/VocabularySelectField.jsx
@@ -25,7 +25,9 @@ export const VocabularySelectField = ({
 
   function _serializeSuggestions(suggestions) {
     // We need to do post-filtering here (it seems impossible to add pre-filter to suggestion API query)
-    return serializeVocabularySuggestions(suggestions).filter(opt => filterFunction(opt));
+    return serializeVocabularySuggestions(suggestions).filter((opt) =>
+      filterFunction(opt)
+    );
   }
 
   return (
@@ -53,9 +55,5 @@ VocabularySelectField.propTypes = {
 VocabularySelectField.defaultProps = {
   multiple: false,
   externalAuthority: false,
-  suggestionAPIHeaders: {
-    // TODO: remove after #BE-96 gets resolved
-    Accept: "application/json",
-  },
-  filterFunction: opt => opt,
+  filterFunction: (opt) => opt,
 };

--- a/oarepo_vocabularies/ui/theme/assets/semantic-ui/js/oarepo_vocabularies_ui/form/util.js
+++ b/oarepo_vocabularies/ui/theme/assets/semantic-ui/js/oarepo_vocabularies_ui/form/util.js
@@ -44,7 +44,10 @@ export const serializeVocabularySuggestions = (suggestions) =>
         value: item.id,
         key: key,
         id: item.id,
-        title: item.title,
+        // really funky issue with SUI where if title is a string, the dropdown crashes. And as
+        // we are using vnd serialization now, you get title as a string
+        title:
+          typeof item?.title === "string" ? { cs: item?.title } : item?.title,
         name: getTitleFromMultilingualObject(item?.title),
       };
     }

--- a/oarepo_vocabularies/ui/theme/assets/semantic-ui/js/oarepo_vocabularies_ui/form/util.js
+++ b/oarepo_vocabularies/ui/theme/assets/semantic-ui/js/oarepo_vocabularies_ui/form/util.js
@@ -2,6 +2,7 @@ import * as React from "react";
 import { Breadcrumb, Popup, Icon } from "semantic-ui-react";
 import _join from "lodash/join";
 import { getTitleFromMultilingualObject } from "@js/oarepo_ui";
+import { i18next } from "@translations/oarepo_vocabularies_ui/i18next";
 
 export const serializeVocabularySuggestions = (suggestions) =>
   suggestions.map((item) => {
@@ -47,7 +48,9 @@ export const serializeVocabularySuggestions = (suggestions) =>
         // really funky issue with SUI where if title is a string, the dropdown crashes. And as
         // we are using vnd serialization now, you get title as a string
         title:
-          typeof item?.title === "string" ? { cs: item?.title } : item?.title,
+          typeof item?.title === "string"
+            ? { [i18next.language]: item?.title }
+            : item?.title,
         name: getTitleFromMultilingualObject(item?.title),
       };
     }

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = oarepo-vocabularies
-version = 2.2.0
+version = 2.2.1
 description = Support for custom fields and hierarchy on Invenio vocabularies
 authors = Mirek Simek <miroslav.simek@cesnet.cz>
 readme = README.md


### PR DESCRIPTION
While writing the docs, realized remote VocabularySelectField is not really working (when I for example replace one of localvocabulary selects with it). 

 File "/home/dusanst/Projects/new_nr_docs/nr-docs/.venv/lib/python3.12/site-packages/opensearchpy/connection/http_urllib3.py", line 308, in perform_request
    self._raise_error(
  File "/home/dusanst/Projects/new_nr_docs/nr-docs/.venv/lib/python3.12/site-packages/opensearchpy/connection/base.py", line 315, in _raise_error
    raise HTTP_EXCEPTIONS.get(status_code, TransportError)(
opensearchpy.exceptions.RequestError: RequestError(400, 'mapper_parsing_exception', "failed to parse field [metadata.languages.hierarchy.title] of type [text] in document with id 'c025faf4-7f42-4ba5-bcac-5636236a68f5'. Preview of field's value: '{cs=dánština, en=Danish}'")


The fix is not really a good solution. I think we will really have to sit down to see what we will do about vocabulary fields/global serialization, because also debugging and knowing which properties are used where in the serializers we have, is really a nightmare.