### PR TITLE
Bump version to 5.0.0 and update dependencies for compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "oarepo-vocabularies"
-version = "4.0.0"
+version = "5.0.0"
 description = "Support for custom fields and hierarchy on Invenio vocabularies"
 authors = [
     { name = "Mirek Simek", email = "miroslav.simek@cesnet.cz" }
@@ -17,8 +17,8 @@ dependencies = [
     "orcid",
     "oarepo[rdm,tests]>=14,<15",
     "tqdm",
-    "oarepo-runtime>=3.0.0,<4.0.0",
-    "oarepo-ui>=8.0.0,<9.0.0",
+    "oarepo-runtime>=4.0.0,<5.0.0",
+    "oarepo-ui>=9.0.0,<10.0.0",
 
     # invenio dependencies
     "invenio-search>=3.0.0,<4.0.0",


### PR DESCRIPTION
## Summary

This PR bumps the major version to **5.0.0** to align with breaking changes in upstream dependencies.

## Breaking Changes

### Dependency Updates
- **oarepo-runtime**: `>=2.0.0dev0,<3.0.0` → `>=4.0.0,<5.0.0` (major release)
- **oarepo-ui**: `>=6.0.0dev1,<8.0.0` → `>=9.0.0,<10.0.0` (major release)
- **invenio-search**: Added `>=3.0.0,<4.0.0` (major release)
- **invenio-vocabularies**: Added `>=11.0.0,<12.0.0` (major release)
- **pytest-invenio**: Added `>=4.0.0,<5.0.0` (major release)
- **invenio-app**: Added `>=3.0.0,<4.0.0` (major release)

### Python Version
- Bumped minimum Python version to `>=3.14,<3.15`

### Version Specification
- Changed from dynamic versioning (`tool.hatch.version`) to static `version = "5.0.0"`

## Migration Notes

Projects depending on `oarepo-vocabularies` should:
1. Update their own `oarepo-runtime` dependency to v4.x
2. Update their `oarepo-ui` dependency to v9.x  
3. Ensure compatibility with `invenio-rdm-records` v12.x ecosystem
4. Use Python 3.14+