### PR TITLE
fix: edge case - id might not be set when systemfield is called

### DIFF
--- a/oarepo_vocabularies/records/systemfields/hierarchy_system_field.py
+++ b/oarepo_vocabularies/records/systemfields/hierarchy_system_field.py
@@ -49,7 +49,7 @@ class HierarchyObject:
                 self._hierarchy_data.parent_id = (
                     getattr(self._record.parent, "uuid", None) if hasattr(self._record, "parent") else None
                 )
-                self._hierarchy_data.pid = self._record["id"]
+                self._hierarchy_data.pid = self._record.get("id")
                 self._hierarchy_data.titles = [self._record.get("title")]
 
     @property

--- a/oarepo_vocabularies/records/systemfields/parent_system_field.py
+++ b/oarepo_vocabularies/records/systemfields/parent_system_field.py
@@ -114,7 +114,7 @@ class ParentSystemField(MappingSystemFieldMixin, SystemField):
         if len(direct_children) > 0:
             raise ValidationError(
                 {
-                    "parent": f"Cannot delete a vocabulary term with ID {record['id']} "
+                    "parent": f"Cannot delete a vocabulary term with ID {record.get('id')} "
                     "that has children. Reassign or delete children first."
                 }
             )


### PR DESCRIPTION
I've got an error during indexing, this should fix that. Replaced `["id"] with .get("id")`.

```
[2026-06-24 12:32:07,244: ERROR/MainProcess] Failed to index record db28feeb-8d23-4e06-b828-bb18db8d69f4
Traceback (most recent call last):
  File "datarepo/.venv/lib/python3.14/site-packages/invenio_indexer/api.py", line 370, in _actionsiter
    yield self._index_action(payload)
          ~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "datarepo/.venv/lib/python3.14/site-packages/invenio_indexer/api.py", line 419, in _index_action
    body = self._prepare_record(record, index, arguments)
  File "datarepo/.venv/lib/python3.14/site-packages/invenio_indexer/api.py", line 459, in _prepare_record
    return record.dumps(dumper=self.record_dumper)
           ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "datarepo/.venv/lib/python3.14/site-packages/invenio_records/api.py", line 237, in dumps
    e.pre_dump(self, data, dumper=dumper)
    ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "datarepo/.venv/lib/python3.14/site-packages/invenio_records/systemfields/base.py", line 271, in pre_dump
    field.pre_dump(record, data, dumper=dumper)
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "datarepo/.venv/lib/python3.14/site-packages/oarepo_vocabularies/records/systemfields/hierarchy_system_field.py", line 211, in pre_dump
    hierarchy_obj = self.__get__(record)  # type: ignore[arg-type]
  File "datarepo/.venv/lib/python3.14/site-packages/oarepo_vocabularies/records/systemfields/hierarchy_system_field.py", line 121, in __get__
    record._hierarchy_cache = HierarchyObject(record)  # noqa: SLF001 # type: ignore[attr-defined]
                              ~~~~~~~~~~~~~~~^^^^^^^^
  File "datarepo/.venv/lib/python3.14/site-packages/oarepo_vocabularies/records/systemfields/hierarchy_system_field.py", line 52, in __init__
    self._hierarchy_data.pid = self._record["id"]
                               ~~~~~~~~~~~~^^^^^^
KeyError: 'id'
```